### PR TITLE
Bump com.fasterxml.jackson.dataformat version to fix CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -443,7 +443,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-xml</artifactId>
-      <version>2.13.3</version>
+      <version>2.14.1</version>
     </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>


### PR DESCRIPTION
Updating this dependency resolves the following CVEs:
* CVE-2022-42003
* CVE-2022-42004
* CVE-2022-40151
* CVE-2022-40152

@slimsag I haven't tested this beyond building the sourcegraph/blobstore image and running a quick `$ ./s3proxy --version`. I don't see anything significant in https://github.com/FasterXML/jackson-dataformats-text/blob/2.15/release-notes/VERSION-2.x though, so can't see it being an issue. You may want to run a test yourself though.